### PR TITLE
update config to increase mAP for model, result increase mAP by 87.5%

### DIFF
--- a/examples/object-detection/experiment/const.yaml
+++ b/examples/object-detection/experiment/const.yaml
@@ -15,20 +15,26 @@ profiling:
  begin_on_batch: 0
  end_after_batch: null
 hyperparameters:
-    lr: 0.02
+    lr: .0004261457
     momentum: 0.9
     global_batch_size: 16
     weight_decay: 1.0e-4
     gamma: 0.1
     warmup: linear
     warmup_iters: 200
-    warmup_ratio: 0.001
+    warmup_ratio: 0.724677 # The fraction between 0-1 that defines the percentage of lr you want to start the lr at
     pretrained_model: "https://storage.googleapis.com/ai-at-scale-pdk-assets/sample-data/pdk-object-detection/pretrained-model/frcnn_xview.pth"
     #finetune_ckpt: "/lus/aiholus1/disk/andrew.mendez/model_479.pth"
     step1: 504 # 14 epochs: 14*36 == 504
     step2: 540 # 15 epochs: 15*36 == 540
     model: fasterrcnn_resnet50_fpn
+    # Dataset
+    #dataset_file: coco
+    #backend: local # specifiy the backend you want to use.  one of: gcs, aws, fake, local
+    #data_dir: "/lus/aiholus1/disk/andrew.mendez/xview_dataset/" # bucket name if using gcs or aws, otherwise directory to dataset
+    #masks: false
     num_workers: 4
+    #device: cuda
 environment:
     image: mendeza/obj-det-pdk-train-env:0.0.2
     environment_variables:
@@ -38,15 +44,15 @@ environment:
 
 scheduling_unit: 400
 min_validation_period:
-    batches: 36 # For training
+    batches: 5 # For training
 
 searcher:
   name: single
   metric: mAP
   smaller_is_better: true
   max_length:
-    batches: 2 # 1*(579/16) = 1*36
-records_per_epoch: 32 # 32 records / 16
+    batches: 10 # 1*(9/16) = 1*1
+records_per_epoch: 9 # 9 records / 16
 resources:
     slots_per_trial: 1
     resource_pool: gpu-pool


### PR DESCRIPTION
Updated the const.yaml file to improve performance of FasterRCNN model. Teammate @denisabrantes pointed out mAP of model after finetuning was 0.08. The performance could result in customer not being confident in the model trained. Investigating the issue, the following insights and updates were discovered:

* Model finetuning uses MultiStepLR Decay, where the original model starts at 0.02, and decays to 0.0002
* The original const.yaml had the settings for pretraining. the dataset for pretraining was much larger, and required a higher learning rate.

I completed the following updates:
* The training datasets is much smaller, so updated the config to reflect appropriate training settings.
* Ran a hyperparameter search over 100 trials, and found the ideal learn rate and warmup ratio to improve performance.

The model after training 10 batches should get around 0.14 mAP, and 0.28 mAP50, a big improvement!