### PR TITLE
Fixed train.py call with correct argument passing

### DIFF
--- a/examples/object-detection/pipelines/_on_prem_training-pipeline.json
+++ b/examples/object-detection/pipelines/_on_prem_training-pipeline.json
@@ -17,7 +17,7 @@
       "/bin/sh"
     ],
     "stdin": [
-      "python train.py --git-url https://git@github.com:/determined-ai/pdk.git --git-ref main --sub-dir examples/object-detection/experiment --config const.yaml --repo object-detection-data --model object-detection --project pdk-object-detection --incremental false"
+      "python train.py --git-url https://git@github.com:/determined-ai/pdk.git --git-ref main --sub-dir examples/object-detection/experiment --config const.yaml --repo object-detection-data --model object-detection --project pdk-object-detection --no-incremental"
     ],
     "image": "pachyderm/pdk:train-v0.0.5",
     "secrets": [

--- a/examples/object-detection/pipelines/training-pipeline.json
+++ b/examples/object-detection/pipelines/training-pipeline.json
@@ -17,7 +17,7 @@
       "/bin/sh"
     ],
     "stdin": [
-      "python train.py --git-url https://git@github.com:/determined-ai/pdk.git --git-ref main --sub-dir examples/object-detection/experiment --config const.yaml --repo object-detection-data --model object-detection --project pdk-object-detection --incremental false"
+      "python train.py --git-url https://git@github.com:/determined-ai/pdk.git --git-ref main --sub-dir examples/object-detection/experiment --config const.yaml --repo object-detection-data --model object-detection --project pdk-object-detection --no-incremental"
     ],
     "image": "pachyderm/pdk:train-v0.0.5",
     "secrets": [


### PR DESCRIPTION
Current `train.py` call in `training_pipeline.json` uses outdated value pass `false` to argument `--incremental`:
```bash
python train.py --git-url https://git@github.com:/determined-ai/pdk.git --git-ref main --sub-dir examples/object-detection/experiment --config const.yaml --repo object-detection-data --model object-detection --project pdk-object-detection --incremental false"
```
This renders the pipeline not functioning as is, resulting in the following error:

```bash
Feb 16, 2024; 13:19 usage: train.py [-h] [--config CONFIG] [--git-url GIT_URL] [--git-ref GIT_REF]
Feb 16, 2024; 13:19                 [--sub-dir SUB_DIR] [--repo REPO] [--project PROJECT]
Feb 16, 2024; 13:19                 [--model MODEL] [--incremental | --no-incremental]
Feb 16, 2024; 13:19 train.py: error: unrecognized arguments: false
```

This PR fixes it by passing `--no-incremental` instead. Tested on k8s GCP deployment and confirmed working.