### PR TITLE
Added support for non-RSA SSH public keys for AWS deployment

### DIFF
--- a/deploy/deploy_aws.md
+++ b/deploy/deploy_aws.md
@@ -123,6 +123,7 @@ All commands listed throghout this document must be executed in the same termina
 # MODIFY THESE VARIABLES
 export NAME="your-name-pdk"
 export AWS_ACCOUNT_ID="555555555555"
+export EKS_SSH_PUBLIC_KEY="~/.ssh/id_rsa.pub"
 
 # VPC SETTINGS
 export AWS_VPC_ID="vpc-0000000000000000x"
@@ -401,6 +402,7 @@ managedNodeGroups:
         efs: true
     ssh:
       allow: true
+      publicKeyPath: ${EKS_SSH_PUBLIC_KEY}
     labels:
       nodegroup-type: cpu-${AWS_AVAILABILITY_ZONE_1}
       nodegroup-role: cpu-worker
@@ -428,6 +430,7 @@ managedNodeGroups:
         efs: true
     ssh:
       allow: true
+      publicKeyPath: ${EKS_SSH_PUBLIC_KEY}
     labels:
       nodegroup-type: gpu-${AWS_AVAILABILITY_ZONE_1}
       nodegroup-role: gpu-worker


### PR DESCRIPTION
Added support for newer encryptions for SSH public keys in the AWS deployment script. This stops the assumption that users will default to older RSA keys which will cause an error if it doesn't match during the eks cluster deployment step.